### PR TITLE
"High inclusion priority" setting

### DIFF
--- a/lib/autocomplete-snippets.coffee
+++ b/lib/autocomplete-snippets.coffee
@@ -1,4 +1,12 @@
 module.exports =
+  config:
+    highInclusionPriority:
+      title: 'High inclusion priority'
+      description: 'Do not allow other packages to suppress this provider (restart required)'
+      type: 'boolean'
+      default: false
+      order: 1
+
   provider: null
 
   activate: ->

--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -5,6 +5,10 @@ module.exports =
 class SnippetsProvider
   selector: '*'
 
+  constructor: ->
+    if atom.config.get('autocomplete-snippets.highInclusionPriority')
+      @inclusionPriority = 9999
+
   getSuggestions: ({scopeDescriptor, prefix}) ->
     return unless prefix?.length
     scopeSnippets = atom.config.get('snippets', {scope: scopeDescriptor})


### PR DESCRIPTION
Some packages like [go-plus](https://github.com/joefitzgerald/go-plus) use `excludeLowerPriority ` property to suppress default provider of autocomplete+, but it would be great to have snippets still working. Checking 'High inclusion priority' setting sets `inclusionPriority ` of autocomplete-snippets to 9999 and doesn't allow to suppress it.