### PR TITLE
Use a string compatible prefix comparator

### DIFF
--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -43,7 +43,8 @@ class SnippetsProvider
   onDidInsertSuggestion: ({editor}) ->
     atom.commands.dispatch(atom.views.getView(editor), 'snippets:expand')
 
-ascendingPrefixComparator = (a, b) -> a.prefix  - b.prefix
+ascendingPrefixComparator = (a, b) ->
+  if a.prefix > b.prefix then 1 else if a.prefix < b.prefix then -1 else 0
 
 firstCharsEqual = (str1, str2) ->
   str1[0].toLowerCase() is str2[0].toLowerCase()

--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -44,9 +44,7 @@ class SnippetsProvider
     atom.commands.dispatch(atom.views.getView(editor), 'snippets:expand')
 
 
-# To the choice of reviewer
-ascendingPrefixComparator = (a, b) -> if a.text > b.text then 1 else if a.text < b.text then -1 else 0
-#ascendingPrefixComparator = (a, b) -> a.text.localeCompare(b.text)
+ascendingPrefixComparator = (a, b) -> a.text.localeCompare(b.text)
 
 firstCharsEqual = (str1, str2) ->
   str1[0].toLowerCase() is str2[0].toLowerCase()

--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -43,8 +43,10 @@ class SnippetsProvider
   onDidInsertSuggestion: ({editor}) ->
     atom.commands.dispatch(atom.views.getView(editor), 'snippets:expand')
 
-ascendingPrefixComparator = (a, b) ->
-  if a.prefix > b.prefix then 1 else if a.prefix < b.prefix then -1 else 0
+
+# To the choice of reviewer
+ascendingPrefixComparator = (a, b) -> if a.text > b.text then 1 else if a.text < b.text then -1 else 0
+#ascendingPrefixComparator = (a, b) -> a.text.localeCompare(b.text)
 
 firstCharsEqual = (str1, str2) ->
   str1[0].toLowerCase() is str2[0].toLowerCase()

--- a/spec/autocomplete-snippets-spec.coffee
+++ b/spec/autocomplete-snippets-spec.coffee
@@ -71,3 +71,27 @@ describe 'AutocompleteSnippets', ->
       runs ->
         atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
         expect(editor.getText()).toContain '} while (true);'
+
+
+  describe 'when showing suggestions', ->
+    it 'sort them in alphabetical order', ->
+
+      unorderedPrefix = [
+        "",
+        "dop",
+        "do",
+        "dad",
+        "d"
+      ]
+
+      snippets = {}
+      snippets[x] = {prefix: x, name:"", description:"", descriptionMoreURL:""} for x in unorderedPrefix
+
+      SnippetsProvider = require('../lib/snippets-provider')
+      sp = new SnippetsProvider()
+      sp.setSnippetsSource( { snippetsForScopes: (scope) -> snippets } )
+      suggestions = sp.getSuggestions( {scopeDescriptor:"*", prefix:"d"} )
+
+      suggestionsText = suggestions.map( (x) -> x.text )
+      expect(suggestionsText).toEqual(["d", "dad", "do", "dop"])
+

--- a/spec/autocomplete-snippets-spec.coffee
+++ b/spec/autocomplete-snippets-spec.coffee
@@ -72,11 +72,9 @@ describe 'AutocompleteSnippets', ->
         atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
         expect(editor.getText()).toContain '} while (true);'
 
-
   describe 'when showing suggestions', ->
-    it 'sort them in alphabetical order', ->
-
-      unorderedPrefix = [
+    it 'sorts them in alphabetical order', ->
+      unorderedPrefixes = [
         "",
         "dop",
         "do",
@@ -85,13 +83,12 @@ describe 'AutocompleteSnippets', ->
       ]
 
       snippets = {}
-      snippets[x] = {prefix: x, name: "", description: "", descriptionMoreURL: ""} for x in unorderedPrefix
+      snippets[x] = {prefix: x, name: "", description: "", descriptionMoreURL: ""} for x in unorderedPrefixes
 
       SnippetsProvider = require('../lib/snippets-provider')
       sp = new SnippetsProvider()
       sp.setSnippetsSource({snippetsForScopes: (scope) -> snippets})
-      suggestions = sp.getSuggestions({scopeDescriptor: "*", prefix: "d"})
+      suggestions = sp.getSuggestions({scopeDescriptor: "", prefix: "d"})
 
       suggestionsText = suggestions.map((x) -> x.text)
       expect(suggestionsText).toEqual(["d", "dad", "do", "dop"])
-

--- a/spec/autocomplete-snippets-spec.coffee
+++ b/spec/autocomplete-snippets-spec.coffee
@@ -85,13 +85,13 @@ describe 'AutocompleteSnippets', ->
       ]
 
       snippets = {}
-      snippets[x] = {prefix: x, name:"", description:"", descriptionMoreURL:""} for x in unorderedPrefix
+      snippets[x] = {prefix: x, name: "", description: "", descriptionMoreURL: ""} for x in unorderedPrefix
 
       SnippetsProvider = require('../lib/snippets-provider')
       sp = new SnippetsProvider()
-      sp.setSnippetsSource( { snippetsForScopes: (scope) -> snippets } )
-      suggestions = sp.getSuggestions( {scopeDescriptor:"*", prefix:"d"} )
+      sp.setSnippetsSource({snippetsForScopes: (scope) -> snippets})
+      suggestions = sp.getSuggestions({scopeDescriptor: "*", prefix: "d"})
 
-      suggestionsText = suggestions.map( (x) -> x.text )
+      suggestionsText = suggestions.map((x) -> x.text)
       expect(suggestionsText).toEqual(["d", "dad", "do", "dop"])
 


### PR DESCRIPTION
fix https://github.com/atom/autocomplete-snippets/issues/61.
May also help [related](https://github.com/atom/language-ruby/issues/130) [issues](https://github.com/jeancroy/fuzzaldrin-plus/issues/9)