### PR TITLE
New optional formatting properties for snippets

### DIFF
--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -34,6 +34,9 @@ class SnippetsProvider
         text: snippet.prefix
         replacementPrefix: prefix
         rightLabel: snippet.name
+        rightLabelHTML: snippet.rightLabelHTML
+        leftLabel: snippet.leftLabel
+        leftLabelHTML: snippet.leftLabelHTML
         description: snippet.description
         descriptionMoreURL: snippet.descriptionMoreURL
 


### PR DESCRIPTION
I added a few new properties to be able to format how `snippets` appear in the autcomplete results. See [this PR for more info](https://github.com/atom/snippets/pull/194).

To be able to pass these new properties to `autocomplete-plus` I've modified `autocomplete-snippets`.

@lee-dohm [This is the bit](https://github.com/PierBover/autocomplete-snippets/blob/master/spec/autocomplete-snippets-spec.coffee#L88-L91) that tests `snippets-provider.coffee`, but it seems those tests are independent of the properties it gets from `snippets` so I haven't touched anything.