### PR TITLE
Configure 'disableForSelector'

### DIFF
--- a/lib/autocomplete-snippets.coffee
+++ b/lib/autocomplete-snippets.coffee
@@ -1,4 +1,11 @@
 module.exports =
+  config:
+    disableForSelector:
+      title: 'Disable Snippet Autocompletion Selector String'
+      description: 'Scope selector for which snippet autocompletion should be disabled'
+      type: 'string'
+      default: '.comment, .string'
+
   provider: null
 
   activate: ->

--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -1,7 +1,7 @@
 module.exports =
 class SnippetsProvider
   selector: '*'
-  disableForSelector: '.comment, .string'
+  disableForSelector: atom.config.get ('autocomplete-snippets.disableForSelector')
   inclusionPriority: 1
   suggestionPriority: 2
 


### PR DESCRIPTION
This modification creates a single value configuration panel which makes the disableForSelector user configurable.  The default value is '.comment, .string' but means the user can more easily change it through configuration.

TODO: the package only reads the configuration value at startup and does not currently listen for a value change.