### PR TITLE
Don't rely on implementation details of autocomplete-plus in tests

### DIFF
--- a/spec/autocomplete-snippets-spec.coffee
+++ b/spec/autocomplete-snippets-spec.coffee
@@ -10,6 +10,7 @@ describe 'AutocompleteSnippets', ->
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
 
+    autocompleteSnippetsMainModule = null
     snippetsMainModule = null
     autocompleteManager = null
 
@@ -20,19 +21,17 @@ describe 'AutocompleteSnippets', ->
           editorView = atom.views.getView(editor)
 
         atom.packages.activatePackage('language-javascript')
+        atom.packages.activatePackage('autocomplete-snippets').then ({mainModule}) ->
+          autocompleteSnippetsMainModule = mainModule
 
-        atom.packages.activatePackage('autocomplete-snippets')
-
-        atom.packages.activatePackage('autocomplete-plus').then (pack) ->
-          autocompleteManager = pack.mainModule.getAutocompleteManager()
-
+        atom.packages.activatePackage('autocomplete-plus')
         atom.packages.activatePackage('snippets').then ({mainModule}) ->
           snippetsMainModule = mainModule
           snippetsMainModule.loaded = false
       ]
 
     waitsFor 'snippets provider to be registered', 1000, ->
-      autocompleteManager?.providerManager.providers.length > 0
+      autocompleteSnippetsMainModule.provider?
 
     waitsFor 'all snippets to load', 3000, ->
       snippetsMainModule.loaded


### PR DESCRIPTION
These implementation details have changed in atom/autocomplete-plus#876

Instead, rely on implementation details of the snippets provider. These tests are really too integrated and touching too much. It would be better to have something more isolated that installs autocomplete-plus as a dev dependency and tests against its API directly.

@ungb Assuming this builds green against the current Atom, you should be able to publish a patch and add it to your branch where you're upgrading autocomplete-plus, and the tests should pass. 🤞 