### PR TITLE
show snippet icons when using new subsequence provider

### DIFF
--- a/lib/snippets-provider.coffee
+++ b/lib/snippets-provider.coffee
@@ -8,7 +8,7 @@ class SnippetsProvider
   filterSuggestions: true
 
   constructor: ->
-    @showIcon = atom.config.get('autocomplete-plus.defaultProvider') is 'Symbol'
+    @showIcon = ['Symbol', 'Subsequence'].includes(atom.config.get('autocomplete-plus.defaultProvider'))
     @snippetsSource =
       snippetsForScopes: (scopeDescriptor) ->
         atom.config.get('snippets', {scope: scopeDescriptor})


### PR DESCRIPTION
When using the "Subsequence" provider in autocomplete-plus, the snippet icon is not present. This should fix that.

![screen shot 2017-10-18 at 5 27 52 pm](https://user-images.githubusercontent.com/520209/31747387-d95a9b64-b429-11e7-9f97-42c1d99c88e8.png)
