### PR TITLE
Don't disable snippets provider in strings and comments

### DIFF
--- a/lib/snippets-provider.js
+++ b/lib/snippets-provider.js
@@ -2,7 +2,6 @@ module.exports =
 class SnippetsProvider {
   constructor() {
     this.selector = '*'
-    this.disableForSelector = '.comment, .string'
     this.inclusionPriority = 1
     this.suggestionPriority = 2
     this.filterSuggestions = true


### PR DESCRIPTION
Fixes #84

🍐 d with @as-cii 

Disabling snippets within strings and comments probably reduces noise in a lot of scenarios, but can create confusion when snippets don't work in certain circumstances. The correct place to handle this would be in snippets themselves, where we would explicitly disable snippets in contexts where they don't make sense. Our current system makes this pretty difficult to achieve though, since most snippets are tied to the entire scope of the target language. This is something to consider when improving snippets in the future.