### PR TITLE
Recognise minimum prefix length

### DIFF
--- a/lib/autocomplete-snippets.js
+++ b/lib/autocomplete-snippets.js
@@ -1,10 +1,28 @@
+const {CompositeDisposable} = require('atom')
+
 module.exports = {
+  subscriptions: null,
   provider: null,
 
-  activate() {},
+  activate() {
+    this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(atom.config.observe('autocomplete-snippets.useAutocompletePlusMinimumWordLength', (value) => {
+      if (!this.provider) return
+      if (value) {
+        this.provider.minPrefixLength = atom.config.get('autocomplete-plus.minimumWordLength')
+      } else {
+        this.provider.minPrefixLength = atom.config.get('autocomplete-snippets.minimumWordLength')
+      }
+    }))
+    this.subscriptions.add(atom.config.observe('autocomplete-snippets.minimumWordLength', (value) => {
+      if (!this.provider || atom.config.get('autocomplete-snippets.useAutocompletePlusMinimumWordLength')) return
+      this.provider.minPrefixLength = value
+    }))
+  },
 
   deactivate() {
     this.provider = null
+    this.subscriptions.dispose()
   },
 
   provide() {

--- a/lib/snippets-provider.js
+++ b/lib/snippets-provider.js
@@ -5,6 +5,9 @@ class SnippetsProvider {
     this.inclusionPriority = 1
     this.suggestionPriority = 2
     this.filterSuggestions = true
+    this.minPrefixLength = atom.config.get('autocomplete-snippets.useAutocompletePlusMinimumWordLength') ?
+      atom.config.get('autocomplete-plus.minimumWordLength') :
+      atom.config.get('autocomplete-snippets.minimumWordLength')
 
     this.showIcon = ['Symbol', 'Subsequence'].includes(atom.config.get('autocomplete-plus.defaultProvider'))
     this.snippetsSource = {
@@ -21,7 +24,7 @@ class SnippetsProvider {
   }
 
   getSuggestions({scopeDescriptor, prefix}) {
-    if (!(prefix != null ? prefix.length : undefined)) { return }
+    if (prefix == null || prefix.length < this.minPrefixLength) { return }
     const scopeSnippets = this.snippetsSource.snippetsForScopes(scopeDescriptor)
     return this.findSuggestionsForPrefix(scopeSnippets, prefix)
   }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,19 @@
         "0.1.0": "consumeSnippets"
       }
     }
+  },
+  "configSchema": {
+    "useAutocompletePlusMinimumWordLength": {
+      "description": "When enabled, the minimum prefix length will be that set for autocomplete-plus",
+      "type": "boolean",
+      "default": true,
+      "order": 1
+    },
+    "minimumWordLength": {
+      "description": "Minimum prefix length when not using the one set for autocomplete-plus",
+      "type": "integer",
+      "default": 3,
+      "order": 2
+    }
   }
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds two settings for prefix length; one to use the value in `autocomplete-plus`, and another to optionally set a different one.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Could just always use the plus value, but users might want to set different values for snippets and literal text.

### Benefits

<!-- What benefits will be realized by the code change? -->
More control over the menu

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
NA

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes https://github.com/atom/autocomplete-snippets/issues/75
Fixes https://github.com/atom/autocomplete-plus/issues/795

And possibly more