### PR TITLE
Remove broken image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Adds snippets to autocomplete+ suggestions
 
-![autocomplete-snippets](http://s7.directupload.net/images/140411/kgdlgsgx.gif)
-
 ## Features
 
 * Adds user snippets and language snippets to the autocomplete+ suggestions list


### PR DESCRIPTION
I see the following on Atom's view of the package with the current image that looks like an ad:

![Image](http://s7.directupload.net/images/140411/kgdlgsgx.gif)

Might need to click it. Consider replacing (for new users) or removing.